### PR TITLE
Clamp voxel intensity range to 0..255

### DIFF
--- a/frontend/public/local-reader.js
+++ b/frontend/public/local-reader.js
@@ -70,6 +70,18 @@ function readNIFTI(data, canvas, slider, coupe) {
     if(isAsegmentationFile) createLegend(classesSegmentation);
     else removeLegend();
     let dims = niftiHeader.dims
+    //compute voxel intensity range
+    let mn = typedData[0];
+    let mx = mn;
+    for (let i = 0; i < (dims[1] * dims[2] * dims[3]); i++) {
+        mn = Math.min(mn, typedData[i]);
+        mx = Math.max(mx, typedData[i]);
+    }
+    //console.log('Voxel intensity range ', typedData[0], mn, mx);
+    // set slope and intercept to convert range to 0..255, 
+    niftiHeader.displayIntercept = mn; //make darkest value 0
+    niftiHeader.displaySlope = 255.0 / (mx - mn); //make brightest value 255
+    //
     let stride = [1, dims[1], dims[1] * dims[2]]
     let array = ndarray(typedData, [dims[1], dims[2], dims[3]], stride).step(1, 1, -1)
 
@@ -121,6 +133,7 @@ function drawIt(canvas, niftiHeader, image, isAsegmentationFile,classesSegmentat
                 canvasImageData = setPixelValue(rowOffset + col, canvasImageData, rgbValue.r, rgbValue.g, rgbValue.b, 255);
             }
             else {
+                value = (value - niftiHeader.displayIntercept) * niftiHeader.displaySlope;
                 canvasImageData = setPixelValue(rowOffset + col, canvasImageData, value, value, value, 255)
             }
         }


### PR DESCRIPTION
The example dataset has an intensity range of 0..603 which needs to be clamped to fit in the 8-bit RGB components that have the range 0..255. This code simply computes the full intensity range and makes the darkest voxel have an intensity of 0 and the brightest have the intensity of 255. A more sophisticated approach is the [RobustRange](https://github.com/niivue/niivue/blob/7490895d14a6c1229d0d201643b3b77b6aabfdfb/src/nvimage.js#L2333) which for most images set the darkest voxel to the 2nd percentile and the brightest to the 98th percentile. The robust range is less susceptible to outliers.

![tumor](https://user-images.githubusercontent.com/8930807/229309254-575cc9ac-af60-412b-a005-fa0389ae7cd2.png)
